### PR TITLE
Add LF_SERVER_TRUST_TOKEN environment variable

### DIFF
--- a/contrib/RedminePublic.pm
+++ b/contrib/RedminePublic.pm
@@ -154,6 +154,22 @@ sub is_lf_server {
     if ($client_ip eq "127.0.0.1") {
         return 1;
     }
+    if (defined $ENV{'LF_SERVER_TRUST_TOKEN'}) {
+      my $token = $ENV{'LF_SERVER_TRUST_TOKEN'};
+      my $query = $resource->args();
+      if ($query) {
+        foreach $arg (split(/&/, $query)) {
+          my ($key, $value) = split(/=/, $arg);
+          if ($key eq "trust_token") {
+            # Faster than uri_unescape(), see https://metacpan.org/pod/URI::Escape#uri_unescape($string,...)
+            $value =~ s/%([0-9A-Fa-f]{2})/chr(hex($1))/eg;
+            if ($value eq $token) {
+              return 1;
+            }
+          }
+        }
+      }
+    }
     return 0;
 }
 


### PR DESCRIPTION
Used for checking the trust_token query parameter in Mercurial URLs, which is used to determine that the request came from the Language Forge server. (IP address checking doesn't work well with Kubernetes deployments, where the IP address can change frequently).